### PR TITLE
fix: update deprecated GitHub Actions in deploy-storybook workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -74,7 +74,7 @@ jobs:
           NODE_ENV: production
 
       - name: Upload build artifacts
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./storybook-static
 
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
       - name: Add deployment summary
         run: |


### PR DESCRIPTION
- Update actions/upload-pages-artifact from v2 to v3
- Update actions/deploy-pages from v2 to v4
- Resolves deprecated artifact actions error blocking main branch deployment

🎯 Generated with [Claude Code](https://claude.ai/code)